### PR TITLE
Add steady_state_gain method to compute steady-state gain

### DIFF
--- a/src/llsi/ltimodel.py
+++ b/src/llsi/ltimodel.py
@@ -284,3 +284,22 @@ class LTIModel(ABC):
                     Frequency vector, complex response, magnitude std, phase std.
         """
         pass
+
+    @abstractmethod
+    def steady_state_gain(self, uncertainty: bool = False) -> Union[np.ndarray, Tuple[np.ndarray, np.ndarray]]:
+        """
+        Compute the steady-state gain of the system.
+
+        The steady-state gain is the value of the frequency response at omega = 0,
+        representing the gain when all transients have settled.
+
+        Args:
+            uncertainty: If True, return standard deviation of the steady-state gain.
+
+        Returns:
+            If uncertainty is False:
+                np.ndarray: Steady-state gain matrix of shape (ny, nu).
+            If uncertainty is True:
+                Tuple[np.ndarray, np.ndarray]: Steady-state gain matrix and standard deviation.
+        """
+        pass

--- a/src/llsi/polynomialmodel.py
+++ b/src/llsi/polynomialmodel.py
@@ -217,6 +217,45 @@ class PolynomialModel(LTIModel):
 
         return omega, H
 
+    def steady_state_gain(self, uncertainty: bool = False) -> Union[np.ndarray, Tuple[np.ndarray, np.ndarray]]:
+        """
+        Compute the steady-state gain of the system.
+
+        For a discrete-time transfer function H(z) = B(z)/A(z) * z^(-nk):
+        Steady-state gain = H(1) = B(1)/A(1)
+
+        Args:
+            uncertainty: If True, return standard deviation of the steady-state gain.
+
+        Returns:
+            If uncertainty is False:
+                np.ndarray: Steady-state gain as a scalar (SISO system).
+            If uncertainty is True:
+                Tuple[np.ndarray, np.ndarray]: Steady-state gain and standard deviation.
+        """
+        # Evaluate polynomials at z=1 (steady-state)
+        # H(1) = B(1) / A(1) * 1^(-nk) = B(1) / A(1)
+        b_sum = np.sum(self.b)
+        a_sum = np.sum(self.a)
+
+        if a_sum == 0:
+            steady_state_gain = np.full((self.ny, self.nu), np.nan)
+        else:
+            steady_state_gain = np.array([[b_sum / a_sum]])
+
+        if uncertainty:
+            if not hasattr(self, "cov") or self.cov is None:
+                return steady_state_gain, None
+
+            def func():
+                return self.steady_state_gain(uncertainty=False).ravel()
+
+            std = self._propagate_uncertainty(func)
+            std = std.reshape(steady_state_gain.shape)
+            return steady_state_gain, std
+
+        return steady_state_gain
+
     def vectorize(self) -> np.ndarray:
         """Return model parameters as a vector."""
         # Usually [b0, b1, ..., a1, a2, ...] (a0 is fixed to 1)

--- a/src/llsi/statespacemodel.py
+++ b/src/llsi/statespacemodel.py
@@ -262,20 +262,43 @@ class StateSpaceModel(LTIModel):
             return omega, H_arr, mag_std, phase_std
 
         return omega, H_arr
-        # Could use scipy.signal.freqresp if we convert to ss.
 
-        eye = np.eye(A.shape[0])
-        for z_ in z:
-            # Solve (zI - A) X = B -> X = (zI - A)^-1 B
-            # Then H = C X + D
-            try:
-                X = scipy.linalg.solve(z_ * eye - A, B)
-                h = C @ X + D
-            except scipy.linalg.LinAlgError:
-                h = np.full((self.ny, self.nu), np.nan)
-            H.append(h)
+    def steady_state_gain(self, uncertainty: bool = False) -> Union[np.ndarray, Tuple[np.ndarray, np.ndarray]]:
+        """
+        Compute the steady-state gain of the system.
 
-        return omega, np.array(H)
+        For a discrete-time state-space model:
+        H(0) = C * (I - A)^(-1) * B + D
+
+        Args:
+            uncertainty: If True, return standard deviation of the steady-state gain.
+
+        Returns:
+            If uncertainty is False:
+                np.ndarray: Steady-state gain matrix of shape (ny, nu).
+            If uncertainty is True:
+                Tuple[np.ndarray, np.ndarray]: Steady-state gain matrix and standard deviation.
+        """
+        eye = np.eye(self.nx)
+        try:
+            # H(0) = C * (I - A)^(-1) * B + D
+            steady_state_gain = self.C @ scipy.linalg.solve(eye - self.A, self.B) + self.D
+        except scipy.linalg.LinAlgError:
+            # If (I - A) is singular, the steady-state gain is undefined (infinite)
+            steady_state_gain = np.full((self.ny, self.nu), np.nan)
+
+        if uncertainty:
+            if not hasattr(self, "cov") or self.cov is None:
+                return steady_state_gain, None
+
+            def func():
+                return self.steady_state_gain(uncertainty=False).ravel()
+
+            std = self._propagate_uncertainty(func)
+            std = std.reshape(steady_state_gain.shape)
+            return steady_state_gain, std
+
+        return steady_state_gain
 
     @classmethod
     def from_PT1(cls, K: float, tauC: float, Ts: float = 1.0) -> "StateSpaceModel":

--- a/tests/test_polynomialmodel.py
+++ b/tests/test_polynomialmodel.py
@@ -223,3 +223,34 @@ def test_frequency(model):
             9.93180262e-01 - 0.08229963j,
         ],
     )
+
+
+def test_steady_state_gain_simple():
+    """Test DC gain for a simple ARX model."""
+    # System: y[k] = 0.5 * y[k-1] + u[k]
+    # A(q) = 1 - 0.5 * q^(-1), B(q) = 1
+    # DC gain = B(1)/A(1) = 1 / (1 - 0.5) = 2.0
+    mod = PolynomialModel(a=[1, -0.5], b=[1], Ts=1.0)
+    steady_state_gain = mod.steady_state_gain()
+    np.testing.assert_allclose(steady_state_gain, [[2.0]])
+
+
+def test_steady_state_gain_with_delay():
+    """Test DC gain for a model with delay."""
+    # System: y[k] = 0.5 * y[k-1] + u[k-1]
+    # A(q) = 1 - 0.5 * q^(-1), B(q) = 1, nk = 1
+    # DC gain = B(1)/A(1) = 1 / (1 - 0.5) = 2.0 (delay doesn't affect DC gain)
+    mod = PolynomialModel(a=[1, -0.5], b=[1], nk=1, Ts=1.0)
+    steady_state_gain = mod.steady_state_gain()
+    np.testing.assert_allclose(steady_state_gain, [[2.0]])
+
+
+def test_steady_state_gain_arx():
+    """Test DC gain for an ARX model with multiple coefficients."""
+    # System: y[k] = 0.8 * y[k-1] - 0.2 * y[k-2] + 0.5 * u[k] + 0.3 * u[k-1]
+    # A(q) = 1 - 0.8 * q^(-1) + 0.2 * q^(-2)
+    # B(q) = 0.5 + 0.3 * q^(-1)
+    # DC gain = B(1)/A(1) = (0.5 + 0.3) / (1 - 0.8 + 0.2) = 0.8 / 0.4 = 2.0
+    mod = PolynomialModel(a=[1, -0.8, 0.2], b=[0.5, 0.3], Ts=1.0)
+    steady_state_gain = mod.steady_state_gain()
+    np.testing.assert_allclose(steady_state_gain, [[2.0]])

--- a/tests/test_statespacemodel.py
+++ b/tests/test_statespacemodel.py
@@ -274,3 +274,35 @@ def test_reduce_order(ss_mod):
     np.testing.assert_allclose(red_mod.A, [[0.84831905]])
     print(s)
     np.testing.assert_allclose(s, [33.17635127, 21.41164539])
+
+
+def test_steady_state_gain_siso():
+    """Test DC gain for a simple SISO state-space model."""
+    # System: x[k+1] = 0.5 * x[k] + u[k], y[k] = x[k]
+    # DC gain = C * (I - A)^(-1) * B + D = 1 * (1 - 0.5)^(-1) * 1 + 0 = 2.0
+    mod = StateSpaceModel(A=[[0.5]], B=[[1.0]], C=[[1.0]], D=[[0.0]], Ts=1.0)
+    steady_state_gain = mod.steady_state_gain()
+    np.testing.assert_allclose(steady_state_gain, [[2.0]])
+
+
+def test_steady_state_gain_mimo():
+    """Test DC gain for a MIMO state-space model."""
+    # Simple 2x2 MIMO system
+    A = np.array([[0.5, 0.0], [0.0, 0.5]])
+    B = np.array([[1.0, 0.0], [0.0, 1.0]])
+    C = np.array([[1.0, 0.0], [0.0, 1.0]])
+    D = np.array([[0.0, 0.0], [0.0, 0.0]])
+    mod = StateSpaceModel(A=A, B=B, C=C, D=D, Ts=1.0)
+    steady_state_gain = mod.steady_state_gain()
+    # Each channel has DC gain of 2.0
+    expected = np.array([[2.0, 0.0], [0.0, 2.0]])
+    np.testing.assert_allclose(steady_state_gain, expected)
+
+
+def test_steady_state_gain_with_d():
+    """Test DC gain with non-zero D matrix."""
+    # System: x[k+1] = 0.5 * x[k] + u[k], y[k] = x[k] + 0.5 * u[k]
+    # DC gain = C * (I - A)^(-1) * B + D = 2.0 + 0.5 = 2.5
+    mod = StateSpaceModel(A=[[0.5]], B=[[1.0]], C=[[1.0]], D=[[0.5]], Ts=1.0)
+    steady_state_gain = mod.steady_state_gain()
+    np.testing.assert_allclose(steady_state_gain, [[2.5]])


### PR DESCRIPTION
Add steady_state_gain method to LTIModel, StateSpaceModel, and PolynomialModel to compute the steady-state gain (frequency response at omega=0).

Closes #30