### PR TITLE
Improve equidistant method in SysIdData (Issue #112)

### DIFF
--- a/src/llsi/sysiddata.py
+++ b/src/llsi/sysiddata.py
@@ -263,6 +263,10 @@ class SysIdData:
         if t_current.size == 0:
             return target
 
+        # Validate that time vector is strictly increasing
+        if not np.all(np.diff(t_current) > 0):
+            raise ValueError("Time vector must be strictly increasing for interpolation")
+
         t_start = t_current[0]
         t_end = t_current[-1]
         t_new = np.linspace(t_start, t_end, N)
@@ -271,17 +275,13 @@ class SysIdData:
             keys = list(target.series.keys())
 
             # Resample each series with its specified method
-            new_matrix = np.empty((len(keys), N))
-            for i, k in enumerate(keys):
+            for k in keys:
                 f = scipy.interpolate.interp1d(
-                    t_current, target.series[k], kind=method_dict[k], axis=0, fill_value="extrapolate"
+                    t_current, target.series[k], kind=method_dict[k], fill_value="extrapolate"
                 )
-                new_matrix[i, :] = f(t_new)
+                target.series[k] = f(t_new)
 
-            for i, k in enumerate(keys):
-                target.series[k] = new_matrix[i, :]
-
-        target.Ts = (t_end - t_start) / (N - 1) if N > 1 else 0.0
+        target.Ts = (t_end - t_start) / (N - 1) if N > 1 else None
         target.t = None
         return target
 

--- a/tests/test_sysiddata.py
+++ b/tests/test_sysiddata.py
@@ -914,3 +914,38 @@ def test_scaling_with_copy():
     # Copy should be scaled
     assert np.allclose(d_scaled["u"], u - np.mean(u))
     assert d_scaled.means["u"] == np.mean(u)
+
+
+def test_equidistant_non_monotonic_time_raises_error():
+    """Test that equidistant raises ValueError for non-monotonic time vector."""
+    # Create data with non-monotonic (decreasing) time vector
+    t = np.array([1.0, 3.0, 2.0, 4.0])  # Not strictly increasing
+    y = np.array([0.0, 1.0, 0.5, 2.0])
+    d = SysIdData(t=t, y=y)
+    
+    with pytest.raises(ValueError, match="Time vector must be strictly increasing"):
+        d.equidistant()
+
+
+def test_equidistant_non_strictly_increasing_raises_error():
+    """Test that equidistant raises ValueError for duplicate time values."""
+    # Create data with duplicate time values
+    t = np.array([1.0, 2.0, 2.0, 3.0])  # Duplicate at index 1 and 2
+    y = np.array([0.0, 1.0, 1.5, 2.0])
+    d = SysIdData(t=t, y=y)
+    
+    with pytest.raises(ValueError, match="Time vector must be strictly increasing"):
+        d.equidistant()
+
+
+def test_equidistant_N1_sets_Ts_to_None():
+    """Test that equidistant with N=1 sets Ts=None instead of 0.0."""
+    t = np.array([0.0, 1.0, 2.0])
+    y = np.array([0.0, 1.0, 2.0])
+    d = SysIdData(t=t, y=y)
+    
+    d.equidistant(N=1, inplace=True)
+    
+    assert d.N == 1
+    assert d.Ts is None
+    assert d.t is None

--- a/tests/test_sysiddata.py
+++ b/tests/test_sysiddata.py
@@ -922,7 +922,7 @@ def test_equidistant_non_monotonic_time_raises_error():
     t = np.array([1.0, 3.0, 2.0, 4.0])  # Not strictly increasing
     y = np.array([0.0, 1.0, 0.5, 2.0])
     d = SysIdData(t=t, y=y)
-    
+
     with pytest.raises(ValueError, match="Time vector must be strictly increasing"):
         d.equidistant()
 
@@ -933,7 +933,7 @@ def test_equidistant_non_strictly_increasing_raises_error():
     t = np.array([1.0, 2.0, 2.0, 3.0])  # Duplicate at index 1 and 2
     y = np.array([0.0, 1.0, 1.5, 2.0])
     d = SysIdData(t=t, y=y)
-    
+
     with pytest.raises(ValueError, match="Time vector must be strictly increasing"):
         d.equidistant()
 
@@ -943,9 +943,9 @@ def test_equidistant_N1_sets_Ts_to_None():
     t = np.array([0.0, 1.0, 2.0])
     y = np.array([0.0, 1.0, 2.0])
     d = SysIdData(t=t, y=y)
-    
+
     d.equidistant(N=1, inplace=True)
-    
+
     assert d.N == 1
     assert d.Ts is None
     assert d.t is None


### PR DESCRIPTION
## Summary

Implements improvements to the `equidistant()` method in `SysIdData` as discussed in Issue #112.

### Changes Made

1. **Added validation for strictly increasing time vector** - Raises `ValueError` if time vector is not strictly monotonic increasing (handles both decreasing and duplicate time values)

2. **Simplified interpolation loop** - Removed unnecessary intermediate `new_matrix` array, directly assigning interpolated values to `target.series[k]` for better memory efficiency

3. **Removed redundant `axis=0` parameter** - Removed from `interp1d` call (default for 1D arrays)

4. **Fixed N=1 edge case** - Changed `Ts` from `0.0` to `None` when `N=1` (single point has no sampling time)

5. **Added tests** - Three new tests:
   - `test_equidistant_non_monotonic_time_raises_error` - Tests decreasing time vector
   - `test_equidistant_non_strictly_increasing_raises_error` - Tests duplicate time values
   - `test_equidistant_N1_sets_Ts_to_None` - Tests N=1 edge case

### Decisions

- **Preserve original time vector**: NOT implemented - Per discussion, original time vector is meaningless after interpolation. Users should create a copy before manipulating if needed.
- **Extrapolation warning**: NOT implemented - Cannot occur with current `np.linspace(t_start, t_end, N)` implementation.

### Verification

All 66 tests in `test_sysiddata.py` pass.

Closes #112
