### PR TITLE
Add conditional anti-aliasing filtering to crop() and slicing warnings

### DIFF
--- a/src/llsi/sysiddata.py
+++ b/src/llsi/sysiddata.py
@@ -143,7 +143,7 @@ class SysIdData:
                 warnings.warn(
                     f"Slicing with step={step} performs downsampling without anti-aliasing filtering, "
                     f"which may cause aliasing. Use downsample({step}) or crop(step={step}, anti_alias=True) for safe downsampling.",
-                    stacklevel=2
+                    stacklevel=2,
                 )
 
             # If it's a simple contiguous slice, use crop (safer for metadata)
@@ -470,7 +470,14 @@ class SysIdData:
 
         return target
 
-    def crop(self, start: Optional[int] = None, end: Optional[int] = None, step: Optional[int] = None, inplace: bool = True, anti_alias: bool = True) -> "SysIdData":
+    def crop(
+        self,
+        start: Optional[int] = None,
+        end: Optional[int] = None,
+        step: Optional[int] = None,
+        inplace: bool = True,
+        anti_alias: bool = True,
+    ) -> "SysIdData":
         """
         Crop the data to a subset of samples.
 
@@ -532,7 +539,7 @@ class SysIdData:
                     warnings.warn(
                         "Anti-aliasing filter cannot be applied to non-equidistant data. "
                         "Downsampling without filtering may cause aliasing.",
-                        stacklevel=2
+                        stacklevel=2,
                     )
                 # Just downsample without filtering
                 for k, v in target:

--- a/src/llsi/sysiddata.py
+++ b/src/llsi/sysiddata.py
@@ -26,6 +26,7 @@ class SysIdData:
     - Method chaining for fluent API design
     - Flexible data manipulation (crop, resample, filter, differentiate)
     - Pythonic interface (slicing, iteration, len)
+    - Safe downsampling with anti-aliasing filters
 
     Examples:
         >>> # Create equidistant data
@@ -34,6 +35,14 @@ class SysIdData:
         >>> train_data = data[:1000]
         >>> # Method chaining
         >>> data.equidistant(N=500).lowpass(order=4, corner_frequency=10).plot()
+
+    Note:
+        When downsampling (reducing the number of samples), use methods that apply
+        anti-aliasing filters to prevent aliasing:
+        - downsample(q): Safe downsampling by factor q with anti-aliasing
+        - crop(step=q, anti_alias=True): Safe downsampling with range selection
+        Avoid using slicing with step > 1 (e.g., data[::2]) as it does not apply
+        anti-aliasing and may introduce aliasing.
     """
 
     series: dict[str, np.ndarray] = field(default_factory=dict)
@@ -113,6 +122,11 @@ class SysIdData:
             data["u"]      -> Returns numpy array of series 'u'
             data[0:100]    -> Returns a NEW SysIdData object cropped to first 100 samples
             data[:50]      -> First 50 samples
+
+        Note:
+            When using slicing with step > 1 (e.g., data[::2]), a warning is issued
+            because this performs downsampling without anti-aliasing filtering, which
+            may cause aliasing. For safe downsampling, use downsample() or crop(step=q, anti_alias=True).
         """
         if isinstance(key, str):
             return self.series[key]
@@ -125,10 +139,12 @@ class SysIdData:
             step = key.step if isinstance(key, slice) else 1
 
             if step is not None and step != 1:
-                # Use downsample logic if step > 1? For now, standard slicing.
-                # Standard array slicing supports steps, so we can support it manually
-                # but crop() is range based. Let's use crop for contiguous slices.
-                pass
+                # Warn about potential aliasing when using step > 1
+                warnings.warn(
+                    f"Slicing with step={step} performs downsampling without anti-aliasing filtering, "
+                    f"which may cause aliasing. Use downsample({step}) or crop(step={step}, anti_alias=True) for safe downsampling.",
+                    stacklevel=2
+                )
 
             # If it's a simple contiguous slice, use crop (safer for metadata)
             if step is None or step == 1:
@@ -454,36 +470,91 @@ class SysIdData:
 
         return target
 
-    def crop(self, start: Optional[int] = None, end: Optional[int] = None, inplace: bool = True) -> "SysIdData":
+    def crop(self, start: Optional[int] = None, end: Optional[int] = None, step: Optional[int] = None, inplace: bool = True, anti_alias: bool = True) -> "SysIdData":
         """
         Crop the data to a subset of samples.
 
         Args:
             start: Start index (default: 0).
             end: End index (default: N, exclusive).
+            step: Step size for downsampling (default: None, meaning 1). If > 1, the data is downsampled.
             inplace: If True, modify in-place. If False, return a copy.
+            anti_alias: If True (default) and step > 1, apply anti-aliasing filter before downsampling.
+                       Only applies to equidistant data. For non-equidistant data, a warning is issued.
 
         Returns:
             SysIdData: The cropped object (self if inplace=True, copy if inplace=False).
+
+        Note:
+            When step > 1, this performs downsampling. With anti_alias=True (default), an anti-aliasing
+            filter is applied to prevent aliasing. Use anti_alias=False only if you are certain
+            the signal has no frequency content above the new Nyquist frequency.
         """
         start = start or 0
         end = end or self.N
+        step = step or 1
 
         target = self if inplace else copy.deepcopy(self)
 
-        # Update time vector
-        if target.t is not None:
-            # Non-equidistant: crop time vector and update t_start
-            target.t = target.t[start:end]
-            if len(target.t) > 0:
-                target.t_start = float(target.t[0])
+        # If step > 1, we need to downsample
+        if step > 1:
+            # Check if we have equidistant data
+            if target.Ts is not None:
+                # Equidistant data: apply anti-aliasing if requested
+                if anti_alias:
+                    # Apply decimate with anti-aliasing filter
+                    for k, v in target:
+                        # First crop to the range, then decimate
+                        cropped_v = v[start:end]
+                        target.series[k] = scipy.signal.decimate(cropped_v, step)
+                    # Update time vector
+                    if target.t is not None:
+                        target.t = target.t[start:end:step]
+                        if len(target.t) > 0:
+                            target.t_start = float(target.t[0])
+                    else:
+                        target.t_start += target.Ts * start
+                        target.Ts *= step
+                else:
+                    # No anti-aliasing, just downsample
+                    for k, v in target:
+                        target.series[k] = v[start:end:step]
+                    if target.t is not None:
+                        target.t = target.t[start:end:step]
+                        if len(target.t) > 0:
+                            target.t_start = float(target.t[0])
+                    else:
+                        target.t_start += target.Ts * start
+                        target.Ts *= step
+            else:
+                # Non-equidistant data: cannot apply anti-aliasing filter
+                if anti_alias:
+                    warnings.warn(
+                        "Anti-aliasing filter cannot be applied to non-equidistant data. "
+                        "Downsampling without filtering may cause aliasing.",
+                        stacklevel=2
+                    )
+                # Just downsample without filtering
+                for k, v in target:
+                    target.series[k] = v[start:end:step]
+                target.t = target.t[start:end:step]
+                if len(target.t) > 0:
+                    target.t_start = float(target.t[0])
         else:
-            # Equidistant: update t_start based on the number of skipped samples
-            target.t_start += target.Ts * start
+            # step == 1, normal cropping
+            # Update time vector
+            if target.t is not None:
+                # Non-equidistant: crop time vector and update t_start
+                target.t = target.t[start:end]
+                if len(target.t) > 0:
+                    target.t_start = float(target.t[0])
+            else:
+                # Equidistant: update t_start based on the number of skipped samples
+                target.t_start += target.Ts * start
 
-        # Crop all series
-        for k, v in target:
-            target.series[k] = v[start:end]
+            # Crop all series
+            for k, v in target:
+                target.series[k] = v[start:end]
 
         return target
 
@@ -538,10 +609,19 @@ class SysIdData:
         """
         Downsample the data by an integer factor.
 
-        Applies an anti-aliasing filter (Chebyshev type I) before downsampling.
+        Applies an anti-aliasing filter (Chebyshev type I) before downsampling to prevent
+        aliasing. This is the recommended method for safe downsampling of equidistant data.
 
         Args:
-            q: Downsampling factor.
+            q: Downsampling factor (must be >= 1).
+            inplace: If True, modify in-place. If False, return a copy.
+
+        Returns:
+            SysIdData: The downsampled object (self if inplace=True, copy if inplace=False).
+
+        Note:
+            For non-equidistant data, use crop(step=q, anti_alias=False) or resample() instead.
+            For downsampling with a specific start/end range, use crop(start, end, step=q, anti_alias=True).
         """
         target = self if inplace else copy.deepcopy(self)
         if q < 1:

--- a/tests/test_sysiddata.py
+++ b/tests/test_sysiddata.py
@@ -949,3 +949,114 @@ def test_equidistant_N1_sets_Ts_to_None():
     assert d.N == 1
     assert d.Ts is None
     assert d.t is None
+
+
+# --- Tests for anti-aliasing in crop and slicing ---
+
+
+def test_crop_with_step_and_anti_alias():
+    """Test that crop with step > 1 applies anti-aliasing by default."""
+    # Create a signal with high frequency content
+    N = 1000
+    Ts = 0.001
+    t = np.arange(N) * Ts
+    # High frequency signal (100 Hz) that would alias if not filtered
+    high_freq = np.sin(2 * np.pi * 100 * t)
+    data = SysIdData(Ts=Ts, y=high_freq)
+
+    # Crop with step=2 and anti_alias=True (default)
+    cropped = data.crop(start=0, end=N, step=2, inplace=False)
+
+    # Check that the output has the correct number of samples
+    assert cropped.N == N // 2
+    # Check that Ts is updated correctly
+    assert np.isclose(cropped.Ts, Ts * 2)
+
+
+def test_crop_with_step_no_anti_alias():
+    """Test that crop with step > 1 and anti_alias=False does not apply filtering."""
+    N = 100
+    Ts = 0.01
+    t = np.arange(N) * Ts
+    # Simple signal
+    signal = np.arange(N, dtype=float)
+    data = SysIdData(Ts=Ts, y=signal)
+
+    # Crop with step=2 and anti_alias=False
+    cropped = data.crop(start=0, end=N, step=2, anti_alias=False, inplace=False)
+
+    # Check that the output has the correct number of samples
+    assert cropped.N == N // 2
+    # Check that Ts is updated correctly
+    assert np.isclose(cropped.Ts, Ts * 2)
+    # Check that the values are simply every other sample (no filtering)
+    np.testing.assert_array_equal(cropped["y"], signal[::2])
+
+
+def test_crop_with_step_non_equidistant_warns():
+    """Test that crop with step > 1 on non-equidistant data issues a warning."""
+    t = np.array([0.0, 0.1, 0.3, 0.7, 1.1, 1.8, 2.5, 3.0])
+    y = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0])
+    data = SysIdData(t=t, y=y)
+
+    # This should issue a warning about anti-aliasing not being applicable
+    with pytest.warns(UserWarning, match="Anti-aliasing filter cannot be applied"):
+        cropped = data.crop(start=0, end=8, step=2, anti_alias=True, inplace=False)
+
+    # Check that it still downsamples
+    assert cropped.N == 4
+
+
+def test_slicing_with_step_warns():
+    """Test that slicing with step > 1 issues a warning about aliasing."""
+    N = 100
+    Ts = 0.01
+    t = np.arange(N) * Ts
+    signal = np.arange(N, dtype=float)
+    data = SysIdData(Ts=Ts, y=signal)
+
+    # This should issue a warning about aliasing
+    with pytest.warns(UserWarning, match="Slicing with step=.*performs downsampling without anti-aliasing"):
+        sliced = data[::2]
+
+    # Check that it still downsamples
+    assert sliced.N == N // 2
+    assert np.isclose(sliced.Ts, Ts * 2)
+
+
+def test_crop_step_1_no_anti_alias_needed():
+    """Test that crop with step=1 (default) works normally without anti-aliasing."""
+    N = 100
+    Ts = 0.01
+    t = np.arange(N) * Ts
+    signal = np.arange(N, dtype=float)
+    data = SysIdData(Ts=Ts, y=signal)
+
+    # Crop with step=1 (default)
+    cropped = data.crop(start=10, end=50, inplace=False)
+
+    # Check that it crops correctly
+    assert cropped.N == 40
+    np.testing.assert_array_equal(cropped["y"], signal[10:50])
+
+
+def test_crop_with_step_and_anti_alias_preserves_metadata():
+    """Test that crop with step > 1 preserves metadata correctly."""
+    N = 100
+    Ts = 0.01
+    t_start = 1.0
+    signal = np.arange(N, dtype=float)
+    data = SysIdData(Ts=Ts, t_start=t_start, y=signal)
+
+    # Crop with step=2
+    cropped = data.crop(start=0, end=N, step=2, inplace=False)
+
+    # Check that t_start is preserved (not changed by step since we start at 0)
+    assert np.isclose(cropped.t_start, t_start)
+    assert np.isclose(cropped.Ts, Ts * 2)
+
+
+def test_downsample_docstring_updated():
+    """Test that downsample method has updated docstring mentioning anti-aliasing."""
+    assert "anti-aliasing" in SysIdData.downsample.__doc__
+    assert "prevent" in SysIdData.downsample.__doc__

--- a/tests/test_sysiddata.py
+++ b/tests/test_sysiddata.py
@@ -977,7 +977,6 @@ def test_crop_with_step_no_anti_alias():
     """Test that crop with step > 1 and anti_alias=False does not apply filtering."""
     N = 100
     Ts = 0.01
-    t = np.arange(N) * Ts
     # Simple signal
     signal = np.arange(N, dtype=float)
     data = SysIdData(Ts=Ts, y=signal)
@@ -1011,7 +1010,6 @@ def test_slicing_with_step_warns():
     """Test that slicing with step > 1 issues a warning about aliasing."""
     N = 100
     Ts = 0.01
-    t = np.arange(N) * Ts
     signal = np.arange(N, dtype=float)
     data = SysIdData(Ts=Ts, y=signal)
 
@@ -1028,7 +1026,6 @@ def test_crop_step_1_no_anti_alias_needed():
     """Test that crop with step=1 (default) works normally without anti-aliasing."""
     N = 100
     Ts = 0.01
-    t = np.arange(N) * Ts
     signal = np.arange(N, dtype=float)
     data = SysIdData(Ts=Ts, y=signal)
 


### PR DESCRIPTION
## Summary
- Add conditional anti-aliasing filtering to `crop()` method with new `step` and `anti_alias` parameters
- Add warning when slicing with `step > 1` to alert users about potential aliasing
- Update docstrings to document aliasing behavior and safe usage patterns
- Add comprehensive tests for new functionality

## Changes

### `crop()` method enhancements
- Added `step` parameter to allow downsampling with a specified step size
- Added `anti_alias` parameter (default `True`) that applies `scipy.signal.decimate` with anti-aliasing filter when `step > 1` for equidistant data
- For non-equidistant data with `step > 1`, issues a warning that anti-aliasing cannot be applied

### Slicing warning
- Added warning in `__getitem__` when slicing with `step > 1` (e.g., `data[::2]`)
- Warning message recommends using `downsample(q)` or `crop(step=q, anti_alias=True)` for safe downsampling

### Documentation updates
- Updated class docstring with note about safe downsampling methods
- Updated `crop()`, `downsample()`, and `__getitem__` docstrings to document aliasing behavior

## Verification
- All existing tests pass (71 passed, 1 skipped due to missing pandas)
- New tests added for:
  - `crop()` with `step > 1` and `anti_alias=True` (default)
  - `crop()` with `step > 1` and `anti_alias=False`
  - `crop()` with `step > 1` on non-equidistant data (warning)
  - Slicing with `step > 1` (warning)
  - `crop()` with `step=1` (normal cropping)
  - Metadata preservation with `crop(step > 1)`

## Addresses
- Closes #104: Improve decimation safety in SysIdData

## After these changes
- `crop(step > 1)` is safe by default (anti-aliasing on)
- `downsample()` continues to use anti-aliasing as before
- Slicing with `step > 1` still works but warns users about aliasing risks
